### PR TITLE
[#5] Define LUMEN_DOMAIN env var in docker-compose

### DIFF
--- a/projects/example-lumen/docker-compose.yml
+++ b/projects/example-lumen/docker-compose.yml
@@ -9,6 +9,8 @@ services:
      - AUTH_ISSUER=${AUTH_ISSUER}
     build: ./../../support/auth/
   api:
+    environment:
+     - LUMEN_DOMAIN=${LUMEN_DOMAIN}
     build: .
     volumes:
      - ./data:/data


### PR DESCRIPTION
This change is needed thus we would like to have the option of developing R code using 

`docker-compose exec api bash` 
and a local .env file with the `test` environments

```
AUTH_USER_PASSWORD=xxxx
AUTH_USER_EMAIL=xxxx
AUTH_CLIENT_ID=xxxx
AUTH_CLIENT_PASSWORD=xxxx
AUTH_ISSUER=xxxx
LUMEN_DOMAIN=xxx

```

Currently all env vars are defined in docker-compose but LUMEN_DOMAIN, that is the change this PR only includes


